### PR TITLE
Test11

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ## Proposed changes
 <!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
 
-This PR addresses Issue: 
+This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]
 
 This PR depends upon the following PRs:
 
@@ -19,7 +19,7 @@ Please delete options that are not relevant.
 ## PR Checklist
 Please delete options that are not relevant.
 - [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
-- [ ] My code follows the style guidelines of this project
+- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] New and existing unit tests pass locally with my changes

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+
+
 jobs:
   
 
@@ -37,37 +39,48 @@ jobs:
         id: extract-changelog
         run: |
           PR_DESCRIPTION="${{ github.event.pull_request.body }}"
-          # check if PR description is identical to template.md
-          TEMPLATE_CONTENT=$(cat .github/pull_request_template.md)
-          if [ "$PR_DESCRIPTION" == "$TEMPLATE_CONTENT" ]; then
-            echo "PR description is identical to pull_request_template.md"
-            exit 1
-          fi
-          # Check if "changelog:" exists in PR description
-          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
-            # Extract text after "changelog:"
-            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p' | tr -d '[:space:]')
-            # Check if extracted CHANGELOG_TEXT is empty
-            if [ -z "$CHANGELOG_TEXT" ]; then
-              echo "The changelog information after 'CHANGELOG:' cannot be empty."
+          echo "$PR_DESCRIPTION" > /tmp/pr_description.txt
+          echo "PR DESCRIPTION saved to /tmp/pr_description.txt."
+          cat /tmp/pr_description.txt
+          
+          # Save the template content to a file
+          TEMPLATE_CONTENT=$(sed 's/"//g' .github/pull_request_template.md)
+          echo "$TEMPLATE_CONTENT" > /tmp/template_content.txt
+          echo "Template content saved to /tmp/template_content.txt."
+          cat /tmp/template_content.txt
+          
+          # Use diff to compare the two files
+          if diff -wB /tmp/pr_description.txt /tmp/template_content.txt > /dev/null; then
+              echo "ERROR: PR description is identical to the template."
               exit 1
-            fi
-            # Extract VERSION: from PR description
-            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\Kv\d+\.\d+\.\d+')
-            echo "Extracted changelog: $CHANGELOG_TEXT"
-            echo "::set-output name=changelog::$CHANGELOG_TEXT"
-            echo "::set-output name=version::$VERSION"
           else
-            echo -e "No changelog and version information found in PR description please add them.\nExpected Format:\nVERSION:vX.XX.X\nCHANGELOG:This is changelog note.\nTo re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
-            exit 1
+              echo "PR description and template are different."
           fi
+           # Check if "changelog:" exists in PR description
+           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
+             # Extract content after "changelog:"
+             CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+             # Check if extracted CHANGELOG_TEXT is empty or identical to the template content
+             if [ -z "$CHANGELOG_TEXT" ] || [ diff -wB /tmp/pr_description.txt /tmp/template_content.txt ]; then
+               echo "The changelog information after 'CHANGELOG:' cannot be empty or identical to pull_request_template.md."
+               exit 1
+             fi
+             # Extract VERSION: from PR description
+             VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\Kv\d+\.\d+\.\d+')
+             echo "Extracted changelog: $CHANGELOG_TEXT"
+             echo "::set-output name=changelog::$CHANGELOG_TEXT"
+             echo "::set-output name=version::$VERSION"
+           else
+             echo -e "No changelog and version information found in PR description please add them.\nExpected Format:\nVERSION:vX.XX.X\nCHANGELOG:This is changelog note.\nTo re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+             exit 1
+           fi
       - name: Check PR body against changelog
         if: steps.check-changelog.outputs.check_commit == 'false'
         run: |
           ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
           ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
           VERSION="${{ steps.extract-changelog.outputs.version }}"
-          
+
           if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
             # Check if version exists in CHANGELOG.md
             if grep -q "^## $VERSION" CHANGELOG.md; then
@@ -96,18 +109,21 @@ jobs:
           fi
 
   check_changelog:
-      if: github.event_name == 'pull_request'
-      needs: update-changelog
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
+    if: github.event_name == 'pull_request'
+    needs: update-changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-        - name: Verify Changelog update
-          run: |
-            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
-              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-              exit 1
-            else
-              echo "changelog was updated successfully."
-            fi
+      - name: Verify Changelog update
+        run: |
+          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+            exit 1
+          else
+            echo "changelog was updated successfully."
+          fi
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Zlux App Server Changelog
 
 All notable changes to the Zlux App Server package will be documented in this file.
+    
+## v2.12.0
+- enhancement: new versions of components can change the location of their plugins, as the app-server will now re-inspect the plugin locations on each startup. (#10)
+
 
 ## v2.11.0
 - This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.(#278)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# github-actions
-# workflows
+


### PR DESCRIPTION
VERSION: v2.12.0
CHANGELOG: enhancement: new versions of components can change the location of their plugins, as the app-server will now re-inspect the plugin locations on each startup.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
To test this you can reorganize a component you have to change the location of a plugin within.
In the example below, i previously had the plugin at '.', and moved it to 'newlocation'.
I inspected that the code worked by reading the json at the bottom after a zowe restart, and it correctly had 'newlocation'.
![location-change](https://github.com/zowe/zlux-app-server/assets/30730276/1980f7f7-b820-4b6f-b31a-952be734e8da)
